### PR TITLE
Typo in test name, remove some test configs

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -70,9 +70,6 @@ com.typesafe.play.prune {
         scala-netty-simple-post,
         scala-netty-download-50k,
         scala-netty-download-chunked-50k,
-        scala-netty-template-simple,
-        scala-netty-template-lang,
-        scala-netty-json-encode,
         scala-netty-upload-1m,
         scala-netty-upload-raw-1m,
         # Scala tests:
@@ -82,9 +79,6 @@ com.typesafe.play.prune {
         scala-minimal-simple-post,
         scala-minimal-download-50k,
         scala-minimal-download-chunked-50k,
-        scala-minimal-template-simple,
-        scala-minimal-template-lang,
-        scala-minimal-json-encode,
         scala-minimal-upload-1m,
         scala-minimal-upload-raw-1m,
         # Java tests:
@@ -106,9 +100,6 @@ com.typesafe.play.prune {
         java-netty-simple-post,
         java-netty-download-50k,
         java-netty-download-chunked-50k,
-        java-netty-template-simple,
-        java-netty-template-lang,
-        java-netty-json-encode,
         java-netty-upload-1m,
         java-netty-upload-raw-1m,
         # Java tests:
@@ -118,9 +109,6 @@ com.typesafe.play.prune {
         java-minimal-simple-post,
         java-minimal-download-50k,
         java-minimal-download-chunked-50k,
-        java-minimal-template-simple,
-        java-minimal-template-lang,
-        java-minimal-json-encode,
         java-minimal-upload-1m,
         java-minimal-upload-raw-1m
       ]
@@ -338,7 +326,7 @@ com.typesafe.play.prune {
       wrkArgs: ["<server.url>/simple"]
     }
     {
-      name: scala-simple-post
+      name: scala-di-simple-post
       description: "Receives a POST request an serve a small plain text response"
       app: scala-di-bench
       wrkArgs: ["-s", "<assets.home>/wrk_post.lua", "<server.url>/simple"]


### PR DESCRIPTION
The test configs were removed because they didn't have definitions. We can add them in later if we want.